### PR TITLE
Update field graphic and starting path for Over Under

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,10 +6,10 @@
  */
 window.onload = function() {
   // create a starting path
-  let p0 = new Vector(-32.3, -6.3);
-  let p1 = new Vector(-41, 49);
-  let p2 = new Vector(-42, 52);
-  let p3 = new Vector(5.2, 6.12);
+  let p0 = new Vector(-20, 10);
+  let p1 = new Vector(-55, 53);
+  let p2 = new Vector(-45, 62);
+  let p3 = new Vector(-5, 62);
   path = new Path(new Spline(p0, p1, p2, p3));
   // start rendering
   setInterval(render, 1000/fps);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -24,7 +24,7 @@ const spacing = 2; // target inches between points
 /**
  * Graphics settings
  */
-const imgTrueWidth = 147.8377757; // the width of the image in inches
+const imgTrueWidth = 144.061; // the width of the image in inches
 const img = new Image; // background image
 img.src = 'images/field.png';
 const fps = 60; // how many frames to render each second


### PR DESCRIPTION
Changes:

 - `field.png` updated from a Spin Up field to an Over Under field for the 2023-2024 VRC season. The resolution is still 4096x4096 and the coordinates are correct.
 - Starting path values in `main.js` have been updated to reflect a path that makes sense for the new field.

Testing:

I have tested the site locally and everything works as intended. The field graphic is updated and the new starting path is reflected.